### PR TITLE
cuenta_yo, Just validators, and Native tokens

### DIFF
--- a/cuenta_yo/aiken.toml
+++ b/cuenta_yo/aiken.toml
@@ -1,7 +1,7 @@
 name = "rcerrud/cuenta_yo"
 version = "0.0.0"
-compiler = "v1.0.29-alpha"
-plutus = "v2"
+compiler = "v1.1.3"
+plutus = "v3"
 license = "Apache-2.0"
 description = "Aiken contracts for project 'rcerrud/cuenta_yo'"
 
@@ -12,5 +12,5 @@ platform = "github"
 
 [[dependencies]]
 name = "aiken-lang/stdlib"
-version = "1.9.0"
+version = "2.1.0"
 source = "github"

--- a/cuenta_yo/validators/cuenta_yo.ak
+++ b/cuenta_yo/validators/cuenta_yo.ak
@@ -1,98 +1,108 @@
-use aiken/hash.{Blake2b_224, Hash}
-use aiken/list.{any}
-use aiken/transaction.{ScriptContext, Spend, Transaction}
-use aiken/transaction/credential.{VerificationKey}
+use aiken/collection/list
+use aiken/crypto.{VerificationKeyHash}
+use cardano/transaction.{OutputReference, Transaction}
 
-type PubKeyHash =
-  Hash<Blake2b_224, VerificationKey>
-
-type TipoCuenta =
+/// - 0 - Cuenta O
+/// - 1 - Cuenta Y
+pub type TipoCuenta =
   Int
 
-// 0 - Cuenta O
-// 1 - Cuenta Y
-
-type DatumYO {
-  firmante_1: PubKeyHash,
-  firmante_2: PubKeyHash,
+pub type DatumYO {
+  firmante_1: VerificationKeyHash,
+  firmante_2: VerificationKeyHash,
   tipo_cuenta: TipoCuenta,
 }
 
-validator {
-  fn cuenta_yo(
-    datum: DatumYO,
+validator cuenta_yo {
+  spend(
+    datum: Option<DatumYO>,
     redeemer: TipoCuenta,
-    sContext: ScriptContext,
-  ) -> Bool {
-    when sContext.purpose is {
-      Spend(_) ->
-        datum.tipo_cuenta == redeemer && cuentas_tipo(
-          datum,
-          sContext.transaction,
-        )
-      _ -> False
+    _utxo: OutputReference,
+    tx_info: Transaction,
+  ) {
+    expect Some(data) = datum
+    and {
+      (data.tipo_cuenta == redeemer)?,
+      cuentas_tipo(data, tx_info)?,
     }
+  }
+
+  else(_) {
+    fail
   }
 }
 
-fn cuentas_tipo(datum: DatumYO, txInfo: Transaction) -> Bool {
+fn cuentas_tipo(datum: DatumYO, tx_info: Transaction) -> Bool {
   when datum.tipo_cuenta is {
+    // Cuenta O:
     0 ->
       comparacion_O(
         datum.firmante_1,
         datum.firmante_2,
-        txInfo.extra_signatories,
+        tx_info.extra_signatories,
       )
+
+    // Cuenta Y:
     1 ->
       comparacion_Y(
         datum.firmante_1,
         datum.firmante_2,
-        txInfo.extra_signatories,
+        tx_info.extra_signatories,
       )
+
     _ -> False
   }
 }
 
 fn comparacion_O(
-  firmante_1: PubKeyHash,
-  firmante_2: PubKeyHash,
-  firmantes: List<PubKeyHash>,
+  firmante_1: VerificationKeyHash,
+  firmante_2: VerificationKeyHash,
+  firmantes: List<VerificationKeyHash>,
 ) {
-  buscarFirma(firmante_1, firmantes) || buscarFirma(firmante_2, firmantes)
+  or {
+    buscarFirma(firmante_1, firmantes)?,
+    buscarFirma(firmante_2, firmantes)?,
+  }
 }
 
 fn comparacion_Y(
-  firmante_1: PubKeyHash,
-  firmante_2: PubKeyHash,
-  firmantes: List<PubKeyHash>,
+  firmante_1: VerificationKeyHash,
+  firmante_2: VerificationKeyHash,
+  firmantes: List<VerificationKeyHash>,
 ) {
-  buscarFirma(firmante_1, firmantes) && buscarFirma(firmante_2, firmantes)
+  and {
+    buscarFirma(firmante_1, firmantes)?,
+    buscarFirma(firmante_2, firmantes)?,
+  }
 }
 
-fn buscarFirma(firma: PubKeyHash, firmas: List<PubKeyHash>) -> Bool {
-  any(firmas, fn(f) { f == firma })
+fn buscarFirma(
+  firma: VerificationKeyHash,
+  firmas: List<VerificationKeyHash>,
+) -> Bool {
+  firmas |> list.any(fn(f) { f == firma })
 }
 
 test prueba_comparaion_O() {
-  comparacion_O("AD81", "BC82", ["AD81", "BC82", "CD35"])
+  comparacion_O("AD81", "BC82", ["AD81", "BC82", "CD35"])?
 }
 
 test prueba_comparacion_Y() {
-  comparacion_Y("AD81", "BC82", ["AD81", "BC82", "CD35"])
+  comparacion_Y("AD81", "BC82", ["AD81", "BC82", "CD35"])?
 }
 
 test prueba_buscarFirma() {
-  buscarFirma("AD81", ["AD81", "BC82"])
+  buscarFirma("AD81", ["AD81", "BC82"])?
 }
 // test prueba_cuentas_tipo() {
-//   cuentas_tipo(0)
+//   cuentas_tipo(0)?
 // }
 // test prueba_cuenta_yo() {
 //   cuenta_yo(
 //     DatumYO { firmante_1: "AD81", firmante_2: "AD82", tipo_cuenta: 0 },
 //     0,
 //     ,
-//   )
+//   )?
 // }
 //1. Crear/Escoger carpeta para el proyecto.
 //2. Crear nuevo andamiaje del proyecto cmd: aiken new <nombre de tu espacio>/<nombre de tu projecto>

--- a/cuenta_yo/validators/cuenta_yo.ak
+++ b/cuenta_yo/validators/cuenta_yo.ak
@@ -36,7 +36,7 @@ fn cuentas_tipo(datum: DatumYO, tx_info: Transaction) -> Bool {
   when datum.tipo_cuenta is {
     // Cuenta O:
     0 ->
-      comparacion_O(
+      comparacion_o(
         datum.firmante_1,
         datum.firmante_2,
         tx_info.extra_signatories,
@@ -44,7 +44,7 @@ fn cuentas_tipo(datum: DatumYO, tx_info: Transaction) -> Bool {
 
     // Cuenta Y:
     1 ->
-      comparacion_Y(
+      comparacion_y(
         datum.firmante_1,
         datum.firmante_2,
         tx_info.extra_signatories,
@@ -54,45 +54,45 @@ fn cuentas_tipo(datum: DatumYO, tx_info: Transaction) -> Bool {
   }
 }
 
-fn comparacion_O(
+fn comparacion_o(
   firmante_1: VerificationKeyHash,
   firmante_2: VerificationKeyHash,
   firmantes: List<VerificationKeyHash>,
 ) {
   or {
-    buscarFirma(firmante_1, firmantes)?,
-    buscarFirma(firmante_2, firmantes)?,
+    buscar_firma(firmante_1, firmantes)?,
+    buscar_firma(firmante_2, firmantes)?,
   }
 }
 
-fn comparacion_Y(
+fn comparacion_y(
   firmante_1: VerificationKeyHash,
   firmante_2: VerificationKeyHash,
   firmantes: List<VerificationKeyHash>,
 ) {
   and {
-    buscarFirma(firmante_1, firmantes)?,
-    buscarFirma(firmante_2, firmantes)?,
+    buscar_firma(firmante_1, firmantes)?,
+    buscar_firma(firmante_2, firmantes)?,
   }
 }
 
-fn buscarFirma(
+fn buscar_firma(
   firma: VerificationKeyHash,
   firmas: List<VerificationKeyHash>,
 ) -> Bool {
   firmas |> list.any(fn(f) { f == firma })
 }
 
-test prueba_comparaion_O() {
-  comparacion_O("AD81", "BC82", ["AD81", "BC82", "CD35"])?
+test prueba_comparaion_o() {
+  comparacion_o("AD81", "BC82", ["AD81", "BC82", "CD35"])?
 }
 
-test prueba_comparacion_Y() {
-  comparacion_Y("AD81", "BC82", ["AD81", "BC82", "CD35"])?
+test prueba_comparacion_y() {
+  comparacion_y("AD81", "BC82", ["AD81", "BC82", "CD35"])?
 }
 
-test prueba_buscarFirma() {
-  buscarFirma("AD81", ["AD81", "BC82"])?
+test prueba_buscar_firma() {
+  buscar_firma("AD81", ["AD81", "BC82"])?
 }
 // test prueba_cuentas_tipo() {
 //   cuentas_tipo(0)?

--- a/justvalidators/aiken.lock
+++ b/justvalidators/aiken.lock
@@ -3,23 +3,23 @@
 
 [[requirements]]
 name = "aiken-lang/stdlib"
-version = "1.9.0"
+version = "2.1.0"
 source = "github"
 
 [[requirements]]
 name = "aiken-lang/fuzz"
-version = "2a6df1220e0d180eb36cfe4e4265a2d47c5b83cb"
+version = "2.1.0"
 source = "github"
 
 [[packages]]
 name = "aiken-lang/stdlib"
-version = "1.9.0"
+version = "2.1.0"
 requirements = []
 source = "github"
 
 [[packages]]
 name = "aiken-lang/fuzz"
-version = "2a6df1220e0d180eb36cfe4e4265a2d47c5b83cb"
+version = "2.1.0"
 requirements = []
 source = "github"
 

--- a/justvalidators/aiken.toml
+++ b/justvalidators/aiken.toml
@@ -1,5 +1,7 @@
 name = "rcerrud/justvalidators"
-version = "0.1.1"
+version = "1.1.1"
+compiler = "v1.1.3"
+plutus = "v3"
 license = "Apache-2.0"
 description = "Aiken contracts for project 'rcerrud/justvalidators'"
 
@@ -10,10 +12,10 @@ platform = "github"
 
 [[dependencies]]
 name = "aiken-lang/stdlib"
-version = "1.9.0"
+version = "2.1.0"
 source = "github"
 
 [[dependencies]]
 name = "aiken-lang/fuzz"
-version = "2a6df1220e0d180eb36cfe4e4265a2d47c5b83cb"
+version = "2.1.0"
 source = "github"

--- a/justvalidators/validators/alwayssucceedsalwaysfails.ak
+++ b/justvalidators/validators/alwayssucceedsalwaysfails.ak
@@ -1,20 +1,45 @@
-validator {
-  fn alwaysSucceeds(_datum: Data, _redeemer: Data, _context: Data) -> Bool {
+validator always_succeeds {
+  spend(
+    _datum: Option<Data>,
+    _redeemer: Data,
+    _output_reference: Data,
+    _transaction: Data,
+  ) {
     True
   }
-}
 
-validator {
-  fn alwaysFails(_datum: Data, _redeemer: Data, _context: Data) -> Bool {
-    False
+  else(_) {
+    fail
   }
 }
 
+validator always_fails {
+  spend(
+    _datum: Option<Data>,
+    _redeemer: Data,
+    _output_reference: Data,
+    _transaction: Data,
+  ) {
+    False
+  }
+
+  else(_) {
+    fail
+  }
+}
 
 test test_numbers() {
-  alwaysSucceeds(1, 2, 3) == True && alwaysFails(1, 2, 3) == False
+  let datum_1: Data = 1
+  and {
+    always_succeeds.spend(Some(datum_1), 2, 3, 4)?,
+    !always_fails.spend(Some(datum_1), 2, 3, 4)?,
+  }
 }
 
 test test_bytestrings() {
-  alwaysSucceeds("a", "b", "c") == True && alwaysFails("a", "b", "c") == False
+  let datum_a: Data = "a"
+  and {
+    always_succeeds.spend(Some(datum_a), "b", "c", "d")?,
+    !always_fails.spend(Some(datum_a), "b", "c", "d")?,
+  }
 }

--- a/justvalidators/validators/commonconditions.ak
+++ b/justvalidators/validators/commonconditions.ak
@@ -3,11 +3,11 @@ use aiken/crypto.{VerificationKeyHash}
 use aiken/interval.{Finite}
 use cardano/transaction.{OutputReference, Transaction, ValidityRange}
 
-pub type POSIXtime =
+pub type PosixTime =
   Int
 
 pub type ConditionsDatum {
-  deadline: POSIXtime,
+  deadline: PosixTime,
   owner: VerificationKeyHash,
   price: Int,
 }
@@ -65,7 +65,7 @@ fn must_be_signed_by(transaction: Transaction, vk: VerificationKeyHash) {
   transaction.extra_signatories |> list.has(vk)
 }
 
-fn must_happen_before(range: ValidityRange, lock_expiration_time: POSIXtime) {
+fn must_happen_before(range: ValidityRange, lock_expiration_time: PosixTime) {
   when range.upper_bound.bound_type is {
     Finite(tx_latest_time) -> (lock_expiration_time >= tx_latest_time)?
     _ -> False

--- a/justvalidators/validators/commonconditions.ak
+++ b/justvalidators/validators/commonconditions.ak
@@ -1,64 +1,73 @@
-use aiken/hash.{Blake2b_224, Hash}
+use aiken/collection/list
+use aiken/crypto.{VerificationKeyHash}
 use aiken/interval.{Finite}
-use aiken/list
-use aiken/transaction.{ScriptContext, Transaction, ValidityRange}
-use aiken/transaction/credential.{VerificationKey}
+use cardano/transaction.{OutputReference, Transaction, ValidityRange}
 
-type ConditionsDatum {
+pub type POSIXtime =
+  Int
+
+pub type ConditionsDatum {
   deadline: POSIXtime,
   owner: VerificationKeyHash,
   price: Int,
 }
 
-type VerificationKeyHash =
-  Hash<Blake2b_224, VerificationKey>
-
-type POSIXtime =
-  Int
-
-type ActionRedeemer {
+pub type ActionRedeemer {
   Owner
   Time
 }
 
-type OurWonderfullDatum {
+pub type OurWonderfullDatum {
   owd: Int,
 }
 
-type OurWonderfullRedeemer {
+pub type OurWonderfullRedeemer {
   owr: Int,
 }
 
-validator {
-  fn ourWonderfullValidator(
-    datum: OurWonderfullDatum,
+validator our_wonderfull_validator {
+  spend(
+    datum: Option<OurWonderfullDatum>,
     redeemer: OurWonderfullRedeemer,
-    _context: Data,
-  ) -> Bool {
-    datum.owd == redeemer.owr
+    _output_reference: OutputReference,
+    _transaction: Transaction,
+  ) {
+    expect Some(data) = datum
+    (data.owd == redeemer.owr)?
+  }
+
+  else(_) {
+    fail
   }
 }
 
-validator {
-  fn conditionator(
-    datum: ConditionsDatum,
+validator conditionator {
+  spend(
+    datum: Option<ConditionsDatum>,
     redeemer: ActionRedeemer,
-    ctx: ScriptContext,
-  ) -> Bool {
+    _output_reference: OutputReference,
+    transaction: Transaction,
+  ) {
+    expect Some(data) = datum
+    let ConditionsDatum { owner, deadline, .. } = data
     when redeemer is {
-      Owner -> must_be_signed_by(ctx.transaction, datum.owner)
-      Time -> must_happen_before(ctx.transaction.validity_range, datum.deadline)
+      Owner -> must_be_signed_by(transaction, owner)?
+      Time -> must_happen_before(transaction.validity_range, deadline)?
     }
+  }
+
+  else(_) {
+    fail
   }
 }
 
 fn must_be_signed_by(transaction: Transaction, vk: VerificationKeyHash) {
-  list.has(transaction.extra_signatories, vk)
+  transaction.extra_signatories |> list.has(vk)
 }
 
 fn must_happen_before(range: ValidityRange, lock_expiration_time: POSIXtime) {
   when range.upper_bound.bound_type is {
-    Finite(tx_latest_time) -> lock_expiration_time >= tx_latest_time
+    Finite(tx_latest_time) -> (lock_expiration_time >= tx_latest_time)?
     _ -> False
   }
 }

--- a/justvalidators/validators/handson_1.ak
+++ b/justvalidators/validators/handson_1.ak
@@ -2,31 +2,52 @@ type MyRedeemer {
   red: Int,
 }
 
-validator {
-  fn handsonNo1(datum: Data, redeemer: Data, _ctx: Data) -> Bool {
-    if datum == redeemer {
+validator handson_no_1 {
+  spend(
+    datum: Option<Data>,
+    redeemer: Data,
+    _output_reference: Data,
+    _transaction: Data,
+  ) {
+    if (datum == Some(redeemer))? {
       True
     } else {
-      expect theredeemer: MyRedeemer = redeemer
-      theredeemer.red == 11
+      expect the_redeemer: MyRedeemer = redeemer
+      (the_redeemer.red == 11)?
     }
+  }
+
+  else(_) {
+    fail
   }
 }
 
-type MyType {
+pub type MyType {
   Unit
   Number { x: Int }
-  YesorNo { yn: Bool }
+  YesNo { yn: Bool }
 }
 
-validator {
-  fn handsNo1r(datum: MyType, redeemer: MyType, _ctx: Data) -> Bool {
+validator hands_no_1_r {
+  spend(
+    datum: Option<MyType>,
+    redeemer: MyType,
+    _output_reference: Data,
+    _transaction: Data,
+  ) {
     when (datum, redeemer) is {
-      (Number(dat1), Number(red2)) -> dat1 == red2
-      (YesorNo(dat1), YesorNo(red2)) -> dat1 == red2
-      (Unit, Unit) -> True
-      (_, Number(red2)) -> red2 == 11
+      (Some(Number(dat1)), Number(red2)) -> (dat1 == red2)?
+      (Some(YesNo(dat1)), YesNo(red2)) -> (dat1 == red2)?
+      (Some(Unit), Unit) -> True
+
+      // this means: allow spending as long as the redeemer is 11, regardless whether a datum exists or not
+      (_, Number(red2)) -> (red2 == 11)?
+
       _ -> False
     }
+  }
+
+  else(_) {
+    fail
   }
 }

--- a/justvalidators/validators/toosimple_validators.ak
+++ b/justvalidators/validators/toosimple_validators.ak
@@ -1,44 +1,73 @@
 use aiken/fuzz
 
-
-type Mydatum {
-  mydatum: Int,
+pub type MyDatum {
+  my_datum: Int,
 }
 
-validator {
-  fn datum22(datum: Data, _redeemer: Data, _context: Data) -> Bool {
-    expect thedatum: Mydatum = datum
-    thedatum.mydatum == 22
+validator datum_22 {
+  spend(
+    datum: Option<MyDatum>,
+    _redeemer: Data,
+    _output_reference: Data,
+    _transaction: Data,
+  ) {
+    expect Some(the_datum) = datum
+    (the_datum.my_datum == 22)?
+  }
+
+  else(_) {
+    fail
   }
 }
 
-type MyRedeemer {
-  myredeemer: Int,
+pub type MyRedeemer {
+  my_redeemer: Int,
 }
 
-validator {
-  fn redeemer11(_datum: Data, redeemer: Data, _context: Data) -> Bool {
-    expect theredeemer: MyRedeemer = redeemer
-    theredeemer.myredeemer == 11
+validator redeemer_11 {
+  spend(
+    _datum: Option<Data>,
+    redeemer: Data,
+    _output_reference: Data,
+    _transaction: Data,
+  ) {
+    expect the_redeemer: MyRedeemer = redeemer
+    (the_redeemer.my_redeemer == 11)?
+  }
+
+  else(_) {
+    fail
   }
 }
 
-validator {
-  fn datumVSredeemer(datum: Data, redeemer: Data, _context: Data) -> Bool {
-    redeemer == datum
+validator datum_vs_redeemer {
+  spend(
+    datum: Option<Data>,
+    redeemer: Data,
+    _output_reference: Data,
+    _transaction: Data,
+  ) {
+    (Some(redeemer) == datum)?
+  }
+
+  else(_) {
+    fail
   }
 }
-
 
 test pbt_numbers(n: Int via fuzz.int()) {
-  datumVSredeemer(n,n,"n/a") == True
+  let datum_n: Data = n
+  datum_vs_redeemer.spend(Some(datum_n), n, "n/a", "n/a")?
 }
-//Must Fail Test
-test mf_pbt_n22_to_r11(n: Int via fuzz.int()) {
-  datumVSredeemer(n,(n+1),"n/a") == False
-}   
 
-//Control Range Test
+/// Must Fail Test
+test mf_pbt_n22_to_r11(n: Int via fuzz.int()) fail {
+  let datum_n: Data = n
+  datum_vs_redeemer.spend(Some(datum_n), n + 1, "n/a", "n/a")
+}
+
+/// Control Range Test
 test pbt_n1000_to_p1000(n via fuzz.list_between(fuzz.int(), -1000, 1000)) {
-  datumVSredeemer(n,n,"n/a") == True
+  let datum_n: Data = n
+  datum_vs_redeemer.spend(Some(datum_n), n, "n/a", "n/a")
 }

--- a/justvalidators/validators/typed_validators.ak
+++ b/justvalidators/validators/typed_validators.ak
@@ -1,35 +1,68 @@
-validator {
-  fn typeddatum22(datum: Int, _redeemer: Data, _context: Data) -> Bool {
-    datum == 22
+validator typed_datum_22 {
+  spend(
+    datum: Option<Int>,
+    _redeemer: Data,
+    _output_reference: Data,
+    _transaction: Data,
+  ) {
+    datum == Some(22)
+  }
+
+  else(_) {
+    fail
   }
 }
 
-validator {
-  fn typedRedeemer11(_datum: Data, redeemer: Int, _context: Data) -> Bool {
+validator typed_redeemer_11 {
+  spend(
+    _datum: Option<Data>,
+    redeemer: Int,
+    _output_reference: Data,
+    _transaction: Data,
+  ) {
     redeemer == 11
   }
-}
 
-validator {
-  fn datumVSredeemer(datum: Int, redeemer: Int, _context: Data) -> Bool {
-    redeemer == datum
+  else(_) {
+    fail
   }
 }
 
-type OurWonderfullDatum {
+validator datum_vs_redeemer {
+  spend(
+    datum: Option<Int>,
+    redeemer: Int,
+    _output_reference: Data,
+    _transaction: Data,
+  ) {
+    Some(redeemer) == datum
+  }
+
+  else(_) {
+    fail
+  }
+}
+
+pub type OurWonderfullDatum {
   owd: Int,
 }
 
-type OurWonderfullRedeemer {
+pub type OurWonderfullRedeemer {
   owr: Int,
 }
 
-validator {
-  fn ourWonderfullValidator(
-    datum: OurWonderfullDatum,
+validator our_wonderfull_validator {
+  spend(
+    datum: Option<OurWonderfullDatum>,
     redeemer: OurWonderfullRedeemer,
-    _context: Data,
-  ) -> Bool {
-    datum.owd == redeemer.owr
+    _output_reference: Data,
+    _transaction: Data,
+  ) {
+    expect Some(data) = datum
+    data.owd == redeemer.owr
+  }
+
+  else(_) {
+    fail
   }
 }

--- a/nativetokens/aiken.lock
+++ b/nativetokens/aiken.lock
@@ -3,12 +3,12 @@
 
 [[requirements]]
 name = "aiken-lang/stdlib"
-version = "1.8.0"
+version = "2.1.0"
 source = "github"
 
 [[packages]]
 name = "aiken-lang/stdlib"
-version = "1.8.0"
+version = "2.1.0"
 requirements = []
 source = "github"
 

--- a/nativetokens/aiken.toml
+++ b/nativetokens/aiken.toml
@@ -1,7 +1,7 @@
 name = "rcerrud/nativetokens"
 version = "0.0.0"
-compiler = "v1.0.29-alpha"
-plutus = "v2"
+compiler = "v1.1.3"
+plutus = "v3"
 license = "Apache-2.0"
 description = "Aiken contracts for project 'rcerrud/nativetokens'"
 
@@ -12,5 +12,5 @@ platform = "github"
 
 [[dependencies]]
 name = "aiken-lang/stdlib"
-version = "1.9.0"
+version = "2.1.0"
 source = "github"

--- a/nativetokens/lib/nativetokens/utils.ak
+++ b/nativetokens/lib/nativetokens/utils.ak
@@ -1,35 +1,52 @@
+use aiken/interval
+use cardano/address
+use cardano/assets
+use cardano/transaction.{Input, NoDatum, Output, OutputReference, Transaction}
 
-use aiken/hash.{Blake2b_224, Hash}
-use aiken/interval.{Finite, before}
+pub fn dummy_transaction() -> Transaction {
+  let utxo_ref =
+    OutputReference(
+      #"0000000000000000000000000000000000000000000000000000000000000000",
+      0,
+    )
 
-use aiken/time.{PosixTime}
-use aiken/transaction.{OutputReference, Transaction, ValidityRange, Mint, TransactionId, Output, NoDatum, Input} as tx
-use aiken/transaction/credential.{from_verification_key}
-use aiken/transaction/value.{PolicyId, from_lovelace, to_minted_value, merge, from_asset}
+  let token_value = assets.from_asset("41D0", #"6e6f5f6e616d655f746f6b656e", 1)
+  let tx_value = assets.from_lovelace(11_000_000) |> assets.merge(token_value)
 
+  // Address { VerificationKeyCredential { "AD812" }, None }:
+  let dummy_addr =
+    address.from_verification_key(
+      #"2070f8488dd696b78a5f23e38d273550e43660526c4b19cba733b488",
+    )
 
-pub fn dummyTransaction() -> Transaction {
- 
-  let utxo_ref = OutputReference(TransactionId {hash: #"0000000000000000000000000000000000000000000000000000000000000000",}, 0)
-  let token_value = from_asset("41D0",#"6e6f5f6e616d655f746f6b656e", 1) 
-  let tx_value = merge(from_lovelace(11000000), token_value)
-  let dummy_addr = from_verification_key(#"2070f8488dd696b78a5f23e38d273550e43660526c4b19cba733b488") //Address{VerificationKeyCredential{"AD812"}, None}
-  let output = Output(dummy_addr, tx_value, NoDatum, None)
-  let input = Input(utxo_ref,Output(dummy_addr, from_lovelace(50000000), NoDatum, None))
-  let minted_value = to_minted_value(token_value)
-  let tx = Transaction(
-      [input],
-      [],
-      [output],
-       from_lovelace(2000000),
-       minted_value,
-       [],
-       [],
-        before(1000000000),
-       [],  //signatores
-       [],  //redeemers
-       dict.new(),  //datums
-       TransactionId("AD812"))
- 
-    tx
+  let output =
+    Output {
+      address: dummy_addr,
+      value: tx_value,
+      datum: NoDatum,
+      reference_script: None,
+    }
+  let input =
+    Input {
+      output_reference: utxo_ref,
+      output: Output {
+        address: dummy_addr,
+        value: assets.from_lovelace(50_000_000),
+        datum: NoDatum,
+        reference_script: None,
+      },
+    }
+
+  let tx =
+    Transaction {
+      ..transaction.placeholder,
+      inputs: [input],
+      outputs: [output],
+      fee: 2_000_000,
+      mint: token_value,
+      validity_range: interval.before(1000000000),
+      id: "AD812",
+    }
+
+  tx
 }

--- a/nativetokens/validators/eacoins.ak
+++ b/nativetokens/validators/eacoins.ak
@@ -1,47 +1,48 @@
-use aiken/hash.{Blake2b_224, Hash}
+use aiken/collection/list
+use aiken/crypto.{VerificationKeyHash}
 use aiken/interval.{Finite}
-use aiken/list
-use aiken/time.{PosixTime}
-use aiken/transaction.{ScriptContext, Transaction, ValidityRange}
-use aiken/transaction/credential.{VerificationKey}
+use cardano/assets.{PolicyId}
+use cardano/transaction.{Transaction, ValidityRange}
 
-type ConditionsRedeemer {
+/// {"constreaNFTctor":0,fields[{"constructor":0,fields:[]},{"int": 1713194931000},{"bytes": "d40e3e791bead1fd8c003f1227906b66a2a1c04e59d663798017db71"},{"int": 50}]}
+pub type ConditionsRedeemer {
   action: Action,
-  deadline: PosixTime,
+  deadline: Int,
   owner: VerificationKeyHash,
   price: Int,
 }
 
-//{"constreaNFTctor":0,fields[{"constructor":0,fields:[]},{"int": 1713194931000},{"bytes": "d40e3e791bead1fd8c003f1227906b66a2a1c04e59d663798017db71"},{"int": 50}]}
-
-type Action {
+pub type Action {
+  /// {"constructor":0,fields:[]}
   Owner
-  //{"constructor":0,fields:[]}
+  /// "constructor":1,fields:[]} 
   Time
 }
 
-//"constructor":1,fields:[]} 
-
-type VerificationKeyHash =
-  Hash<Blake2b_224, VerificationKey>
-
-validator {
-  fn eaCoins(redeemer: ConditionsRedeemer, ctx: ScriptContext) -> Bool {
+validator ea_coins {
+  mint(
+    redeemer: ConditionsRedeemer,
+    _policy_id: PolicyId,
+    transaction: Transaction,
+  ) {
     when redeemer.action is {
-      Owner -> must_be_signed_by(ctx.transaction, redeemer.owner)
-      Time ->
-        must_happen_before(ctx.transaction.validity_range, redeemer.deadline)
+      Owner -> must_be_signed_by(transaction, redeemer.owner)?
+      Time -> must_happen_before(transaction.validity_range, redeemer.deadline)?
     }
+  }
+
+  else(_) {
+    fail
   }
 }
 
 fn must_be_signed_by(transaction: Transaction, vk: VerificationKeyHash) {
-  list.has(transaction.extra_signatories, vk)
+  transaction.extra_signatories |> list.has(vk)
 }
 
-fn must_happen_before(range: ValidityRange, lock_expiration_time: PosixTime) {
+fn must_happen_before(range: ValidityRange, lock_expiration_time: Int) {
   when range.upper_bound.bound_type is {
-    Finite(tx_latest_time) -> lock_expiration_time <= tx_latest_time
+    Finite(tx_latest_time) -> (lock_expiration_time <= tx_latest_time)?
     _ -> False
   }
 }

--- a/nativetokens/validators/eanft.ak
+++ b/nativetokens/validators/eanft.ak
@@ -1,81 +1,91 @@
-use aiken/dict.{to_pairs}
-use aiken/hash.{Blake2b_224, Hash}
+use aiken/collection/dict
+use aiken/collection/list
+use aiken/crypto.{VerificationKeyHash}
 use aiken/interval.{Finite}
-use aiken/list
-use aiken/time.{PosixTime}
-use aiken/transaction.{OutputReference, ScriptContext, Transaction, ValidityRange, Mint, TransactionId, Input} as tx
-use aiken/transaction/credential.{VerificationKey}
-use aiken/transaction/value.{PolicyId,from_minted_value,}
-use nativetokens/utils.{dummyTransaction}
+use cardano/assets.{AssetName, PolicyId}
+use cardano/transaction.{Input, OutputReference, Transaction, ValidityRange}
+use nativetokens/utils
 
-
-type ConditionsRedeemer {
+/// {"constructor":0,fields[{"int":0},{"int": 1713194931000},{"bytes": "d40e3e791bead1fd8c003f1227906b66a2a1c04e59d663798017db71"},{"int": 50}]}
+pub type ConditionsRedeemer {
   action: Action,
-  deadline: PosixTime,
-  owner: PubKeyHash,
+  deadline: Int,
+  owner: VerificationKeyHash,
   price: Int,
 }
 
-//{"constructor":0,fields[{"int":0},{"int": 1713194931000},{"bytes": "d40e3e791bead1fd8c003f1227906b66a2a1c04e59d663798017db71"},{"int": 50}]}
+/// - 0 -> Owner
+/// - 1 -> Time
+pub type Action =
+  Int
 
-type Action = Int
-// 0 -> Owner
-// 1 -> Time
+validator ea_nft(unique_utxo: OutputReference, token_name: AssetName) {
+  mint(
+    redeemer: ConditionsRedeemer,
+    policy_id: PolicyId,
+    transaction: Transaction,
+  ) {
+    and {
+      utxo_spent(unique_utxo, transaction)?,
+      there_can_be_only_one(transaction, policy_id, token_name)?,
+      when redeemer.action is {
+        // Owner:
+        0 -> must_be_signed_by(transaction, redeemer.owner)?
 
-type PubKeyHash =
-  Hash<Blake2b_224, VerificationKey>
+        // Time:
+        1 -> must_happen_before(transaction.validity_range, redeemer.deadline)?
 
+        _ -> False
+      },
+    }
+  }
 
-validator(uniqueUTxO: OutputReference, token_name: ByteArray ) {
-  fn eaNFT(redeemer: ConditionsRedeemer, sContext: ScriptContext) {
-  
-    expect Mint(policy_id) = sContext.purpose
-
-    utxoSpent(uniqueUTxO, sContext.transaction)                      &&
-    there_can_be_only_ONE(sContext.transaction,policy_id,token_name) && 
-    
-    when redeemer.action is {
-      0  -> must_be_signed_by(sContext.transaction, redeemer.owner)
-      1  -> must_happen_before(sContext.transaction.validity_range, redeemer.deadline)
-      _  -> False
+  else(_) {
+    fail
   }
 }
+
+fn utxo_spent(utxo_ref: OutputReference, tx_info: Transaction) {
+  let Transaction { inputs, .. } = tx_info
+  inputs |> list.any(fn(input) { input.output_reference == utxo_ref })
 }
 
-fn utxoSpent(utxo_ref: OutputReference, txInfo: Transaction) {
-  let Transaction(inputs, ..) = txInfo
-  list.any(inputs, fn(input){input.output_reference == utxo_ref })
-}
-
-fn there_can_be_only_ONE(txInfo: Transaction, policy_id: PolicyId, token_name: ByteArray) {
-  let mint = txInfo.mint
-  
+fn there_can_be_only_one(
+  tx_info: Transaction,
+  policy_id: PolicyId,
+  token_name: AssetName,
+) {
+  let Transaction { mint, .. } = tx_info
   expect [Pair(asset_name, amount)] =
-      mint
-        |> from_minted_value
-        |> value.tokens(policy_id)
-        |> dict.to_pairs()
-  
-  amount == 1 && asset_name == token_name
+    mint
+      |> assets.tokens(policy_id)
+      |> dict.to_pairs()
+
+  and {
+    (amount == 1)?,
+    (asset_name == token_name)?,
+  }
 }
 
-fn must_be_signed_by(transaction: Transaction, vk: PubKeyHash) {
-  list.has(transaction.extra_signatories, vk)
+fn must_be_signed_by(transaction: Transaction, vk: VerificationKeyHash) {
+  transaction.extra_signatories |> list.has(vk)
 }
 
-fn must_happen_before(range: ValidityRange, lock_expiration_time: PosixTime) {
+fn must_happen_before(range: ValidityRange, lock_expiration_time: Int) {
   when range.upper_bound.bound_type is {
-    Finite(tx_latest_time) -> lock_expiration_time <= tx_latest_time
+    Finite(tx_latest_time) -> (lock_expiration_time <= tx_latest_time)?
     _ -> False
   }
 }
 
+// ## Tests
 
-
-// Tests
-
-test utxoSpent_test() {
-  let utxo_ref = OutputReference(TransactionId {hash: #"0000000000000000000000000000000000000000000000000000000000000000",}, 0)
-  let tx = dummyTransaction()
-  utxoSpent(utxo_ref, tx) == True
+test utxo_spent_test() {
+  let utxo_ref =
+    OutputReference(
+      #"0000000000000000000000000000000000000000000000000000000000000000",
+      0,
+    )
+  let tx = utils.dummy_transaction()
+  utxo_spent(utxo_ref, tx)?
 }


### PR DESCRIPTION
cuenta_yo:
```gleam
$ aiken c
    Compiling rcerrud/cuenta_yo 0.0.0 (.)
    Compiling aiken-lang/stdlib 2.1.0 (./build/packages/aiken-lang-stdlib)
      Testing ...

    ┍━ cuenta_yo ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │ PASS [mem:  9533, cpu: 2139781] prueba_comparaion_o
    │ PASS [mem: 18494, cpu: 4454898] prueba_comparacion_y
    │ PASS [mem:  7031, cpu: 1587683] prueba_buscar_firma
    ┕━━━━━━━━━━━━━━━━━━━━━━━ 3 tests | 3 passed | 0 failed

      Summary 3 checks, 0 errors, 0 warnings
```
---
Just validators:
```gleam
$ aiken c
    Compiling rcerrud/justvalidators 1.1.1 (.)
    Compiling aiken-lang/stdlib 2.1.0 (./build/packages/aiken-lang-stdlib)
    Compiling aiken-lang/fuzz 2.1.0 (./build/packages/aiken-lang-fuzz)
      Testing ...

    ┍━ alwayssucceedsalwaysfails ━━━━━━━━━━━━━━━━
    │ PASS [mem: 7364, cpu: 1688820] test_numbers
    │ · with traces
    │ | always_fails.spend(Some(datum_1), 2, 3, 4) ? False
    │ PASS [mem: 7364, cpu: 1688820] test_bytestrings
    │ · with traces
    │ | always_fails.spend(Some(datum_a), "b", "c", "d") ? False
    ┕━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2 tests | 2 passed | 0 failed

    ┍━ toosimple_validators ━━━━━━━━━━━━
    │ PASS [after 100 tests] pbt_numbers
    │ PASS [after 100 tests] mf_pbt_n22_to_r11
    │ PASS [after 100 tests] pbt_n1000_to_p1000
    ┕ with --seed=3212691894 → 3 tests | 3 passed | 0 failed

  ⚠ Ignoring file with invalid module name at: "./validators/allconditions.ak.old"
  help: Module names are lowercase, (ascii) alpha-numeric and may contain dashes or underscores.

      Summary 302 checks, 0 errors, 1 warning
```
---
Native tokens:
```gleam
$ aiken c
    Compiling rcerrud/nativetokens 0.0.0 (.)
    Compiling aiken-lang/stdlib 2.1.0 (./build/packages/aiken-lang-stdlib)
      Testing ...

    ┍━ eanft ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │ PASS [mem: 75012, cpu: 21848821] utxo_spent_test
    ┕━━━━━━━━━━━━━━━━━━━ 1 tests | 1 passed | 0 failed

      Summary 1 check, 0 errors, 0 warnings
```